### PR TITLE
Update Init.php

### DIFF
--- a/themecustoms/Theme/Init.php
+++ b/themecustoms/Theme/Init.php
@@ -219,7 +219,7 @@ abstract class Init
 
 		// Add any custom attribute to the html tag
 		// This is useful for things like variants, dark mode, etc.
-		$settings['themecustoms_html_attributes'] = [];
+		$settings['themecustoms_html_attributes'] = '';
 
 		// Define the total amount of custom links to use.
 		$settings['st_custom_links_limit'] = $this->customLinks;


### PR DESCRIPTION
$settings['themecustoms_html_attributes'] has a string value when used in this theme yet it has been initially set as an array in error. This causes an error when the the code attempts to display the variable contents using the null coalescing operator.
( ie. at the onset of of index.template.php )